### PR TITLE
fix(drink-rads): Fixed Drink Radiation Restore

### DIFF
--- a/gamedata/configs/items/items/items_western_goods_drinks.ltx
+++ b/gamedata/configs/items/items/items_western_goods_drinks.ltx
@@ -70,7 +70,7 @@ use_sound                                        = western_goods_drinks\wg_gorba
 snd_on_take                                      = bottle
 
 boost_time                                       = 45
-boost_radiation_restore                          = 0.0009
+boost_radiation_restore                          = 0.0010
 eat_alcohol                                      = 0.2
 eat_satiety                                      = 0.022
 eat_sleepiness                                   = 0.039
@@ -299,7 +299,7 @@ use_sound                                        = western_goods_drinks\wg_redbu
 
 boost_time                                       = 300
 boost_max_weight                                 = 1.65
-boost_radiation_restore                          = 0.0004
+boost_radiation_restore                          = 0.00004
 boost_power_restore                              = 0.003
 eat_alcohol                                      = -0.280
 eat_satiety                                      = 0.113
@@ -413,7 +413,7 @@ break_sound                                      = western_goods_drinks\wg_perri
 use_sound                                        = western_goods_drinks\wg_perrier_can_drink
 
 boost_time                                       = 60
-boost_radiation_restore                          = 0.0004
+boost_radiation_restore                          = 0.0002
 eat_satiety                                      = 0.00
 eat_sleepiness                                   = -0.06
 eat_thirstiness                                  = -3.20
@@ -442,7 +442,7 @@ use_sound                                        = western_goods_drinks\wg_rocks
 
 boost_time                                       = 250
 boost_max_weight                                 = 1.4
-boost_radiation_restore                          = 0.0004
+boost_radiation_restore                          = 0.00004
 boost_power_restore                              = 0.003
 eat_alcohol                                      = -0.280
 eat_satiety                                      = 0.149
@@ -473,7 +473,7 @@ use_sound                                        = western_goods_drinks\wg_monst
 
 boost_time                                       = 260
 boost_max_weight                                 = 1.5
-boost_radiation_restore                          = 0.0004
+boost_radiation_restore                          = 0.00004
 boost_power_restore                              = 0.003
 eat_alcohol                                      = -0.280
 eat_satiety                                      = 0.220


### PR DESCRIPTION
Fixed issue with [abnormally high radiation restore for energy drinks](https://trello.com/c/NDZSOwlq/25-energy-drinks-have-abnormally-high-radiation-restore).