### PR TITLE
feature(mil-spec): Add Milspec To PDA List

### DIFF
--- a/gamedata/scripts/western_goods_utils.script
+++ b/gamedata/scripts/western_goods_utils.script
@@ -915,11 +915,7 @@ function get_real_community(npc, default)
     if not blacklisted_comms[community] then
         return community
     end
-    local npc_squad = get_object_squad(npc)
-    if not npc_squad then
-        return default
-    end
-    local squad_community = npc_squad:get_squad_community()
+    local squad_community = get_object_squad(npc):get_squad_community()
     if not blacklisted_comms[squad_community] then
         return squad_community
     else

--- a/gamedata/scripts/western_goods_utils.script
+++ b/gamedata/scripts/western_goods_utils.script
@@ -796,6 +796,7 @@ function validate_is_pda(obj)
         ["device_pda_1"] = true,
         ["device_pda_2"] = true,
         ["device_pda_3"] = true,
+        ["device_pda_milspec"] = true
     }
 
     return pda_sections[obj:section()]
@@ -914,7 +915,11 @@ function get_real_community(npc, default)
     if not blacklisted_comms[community] then
         return community
     end
-    local squad_community = get_object_squad(npc):get_squad_community()
+    local npc_squad = get_object_squad(npc)
+    if not npc_squad then
+        return default
+    end
+    local squad_community = npc_squad:get_squad_community()
     if not blacklisted_comms[squad_community] then
         return squad_community
     else


### PR DESCRIPTION
* Added the Milspec PDA to the `pda_sections` in `western_goods_utils.validate_is_pda`
<del> * Implemented a nil check in `western_goods_utils.get_real_community` by AnarkisGaming. His note: "_Fixed occasional null exception crash in Generator zone's Monolith War Room. Possible cause? the C-Consciouness people are tagged as Trader and when querying their "true allegiance" it returns a nil or some kind of value that ain't handled by WG properly. I added a basic nil check to make sure WG doesn't crash when encountering such "weird" trader NPC._" </del>