### PR TITLE
feature(missing-squad): Add CTD On Missing Squad

### DIFF
--- a/gamedata/configs/text/eng/st_western_goods_core.xml
+++ b/gamedata/configs/text/eng/st_western_goods_core.xml
@@ -66,6 +66,23 @@
         <text>You can download the latest version from Github : https://github.com/themrdemonized/STALKER-Anomaly-modded-exes</text>
     </string>
 
+    <!-- Squad-less NPC -->
+    <string id="st_err_missing_squad_title">
+        <text>Runtime error - NPC has no squad.</text>
+    </string>
+
+    <string id="st_err_missing_squad_what">
+        <text>Western Goods attempted to get the squad of '%s', but the object has no squad.</text>
+    </string>
+
+    <string id="st_err_missing_squad_why">
+        <text>The game needs NPCs to have squads, in order to run the Alife simulation. Spawning NPCs without squads (which Western Goods does not do!) can permanently damage your save-game.</text>
+    </string>
+
+    <string id="st_err_missing_squad_where">
+        <text>Identify the addon that spawns NPCs without squads (again, it isn't Western Goods), and remove it from your mod list.</text>
+    </string>
+
     <!--=============================================================================================================-->
     <!--    Core Strings                                                                                             -->
     <!--=============================================================================================================-->

--- a/gamedata/configs/text/eng/st_western_goods_core.xml
+++ b/gamedata/configs/text/eng/st_western_goods_core.xml
@@ -66,23 +66,6 @@
         <text>You can download the latest version from Github : https://github.com/themrdemonized/STALKER-Anomaly-modded-exes</text>
     </string>
 
-    <!-- Squad-less NPC -->
-    <string id="st_err_missing_squad_title">
-        <text>Runtime error - NPC has no squad.</text>
-    </string>
-
-    <string id="st_err_missing_squad_what">
-        <text>Western Goods attempted to get the squad of '%s', but the object has no squad.</text>
-    </string>
-
-    <string id="st_err_missing_squad_why">
-        <text>The game needs NPCs to have squads, in order to run the Alife simulation. Spawning NPCs without squads (which Western Goods does not do!) can permanently damage your save-game.</text>
-    </string>
-
-    <string id="st_err_missing_squad_where">
-        <text>Identify the addon that spawns NPCs without squads (again, it isn't Western Goods), and remove it from your mod list.</text>
-    </string>
-
     <!--=============================================================================================================-->
     <!--    Core Strings                                                                                             -->
     <!--=============================================================================================================-->

--- a/gamedata/scripts/western_goods_core.script
+++ b/gamedata/scripts/western_goods_core.script
@@ -2,7 +2,7 @@
 ---                                                                                                                  ---
 ---    Original Author(s) : NLTP_ASHES                                                                               ---
 ---    Edited : N/A                                                                                                  ---
----    Date : 25/12/2023                                                                                             ---
+---    Date : 05/02/2024                                                                                             ---
 ---    License : Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0)           ---
 ---                                                                                                                  ---
 ---    This script holds the 'core' of the addon.                                                                    ---

--- a/gamedata/scripts/western_goods_core.script
+++ b/gamedata/scripts/western_goods_core.script
@@ -82,7 +82,7 @@ function check_addon_removal(status)
 
         -- Check if is Western Goods NPC
         for _,sec in pairs(western_goods_npcs) do
-            if se_obj:section_name() == sec and (not get_object_squad(se_obj)) then
+            if se_obj:section_name() == sec and (not western_goods_utils.get_squad_of(se_obj)) then
                 released_objects = released_objects + 1
                 dbg_printf("[WG] Core | Addon removal releasing squad-less NPC '%s'", se_obj:section_name())
                 alife():release(se_obj)
@@ -116,34 +116,29 @@ end
 function check_prerequisites()
     UnregisterScriptCallback("on_game_load", check_prerequisites)
 
-    local error_message = "Unknown error"
-
     -- Out-of-date game
-    error_message = string.format("\n\n%s\n\n%s\n\n%s\n\n%s",
-            western_goods_utils.get_translation("st_err_outdated_game_title"),
-            western_goods_utils.get_translation("st_err_outdated_game_what"),
-            western_goods_utils.get_translation("st_err_outdated_game_why"),
-            western_goods_utils.get_translation("st_err_outdated_game_where")
-    )
-    assert(is_version_1_5_2(), error_message)
+    assert(is_version_1_5_2(), string.format("\n\n%s\n\n%s\n\n%s\n\n%s",
+        western_goods_utils.get_translation("st_err_outdated_game_title"),
+        western_goods_utils.get_translation("st_err_outdated_game_what"),
+        western_goods_utils.get_translation("st_err_outdated_game_why"),
+        western_goods_utils.get_translation("st_err_outdated_game_where")
+    ))
 
     -- Missing DXML
-    error_message = string.format("\n\n%s\n\n%s\n\n%s\n\n%s",
-            western_goods_utils.get_translation("st_err_missing_dxml_title"),
-            western_goods_utils.get_translation("st_err_missing_dxml_what"),
-            western_goods_utils.get_translation("st_err_missing_dxml_why"),
-            western_goods_utils.get_translation("st_err_missing_dxml_where")
-    )
-    assert(is_dxml_installed(), error_message)
+    assert(is_dxml_installed(), string.format("\n\n%s\n\n%s\n\n%s\n\n%s",
+        western_goods_utils.get_translation("st_err_missing_dxml_title"),
+        western_goods_utils.get_translation("st_err_missing_dxml_what"),
+        western_goods_utils.get_translation("st_err_missing_dxml_why"),
+        western_goods_utils.get_translation("st_err_missing_dxml_where")
+    ))
 
     -- Missing LUA unlocalizer
-    error_message = string.format("\n\n%s\n\n%s\n\n%s\n\n%s",
-            western_goods_utils.get_translation("st_err_missing_unlocalizer_title"),
-            western_goods_utils.get_translation("st_err_missing_unlocalizer_what"),
-            western_goods_utils.get_translation("st_err_missing_unlocalizer_why"),
-            western_goods_utils.get_translation("st_err_missing_unlocalizer_where")
-    )
-    assert(is_lua_unlocalizer_installed() , error_message)
+    assert(is_lua_unlocalizer_installed(), string.format("\n\n%s\n\n%s\n\n%s\n\n%s",
+        western_goods_utils.get_translation("st_err_missing_unlocalizer_title"),
+        western_goods_utils.get_translation("st_err_missing_unlocalizer_what"),
+        western_goods_utils.get_translation("st_err_missing_unlocalizer_why"),
+        western_goods_utils.get_translation("st_err_missing_unlocalizer_where")
+    ))
 end
 
 --- Function used to detect missing translations.

--- a/gamedata/scripts/western_goods_utils.script
+++ b/gamedata/scripts/western_goods_utils.script
@@ -2,7 +2,7 @@
 ---                                                                                                                  ---
 ---    Original Author(s) : NLTP_ASHES                                                                               ---
 ---    Edited : N/A                                                                                                  ---
----    Date : 02/12/2023                                                                                             ---
+---    Date : 05/02/2024                                                                                             ---
 ---    License : Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0)           ---
 ---                                                                                                                  ---
 ---    Script used to define various common functions defined in the scripts of the Western Goods addon.             ---
@@ -713,15 +713,14 @@ function get_squad_of(obj)
         return
     end
 
-    -- Squad can be nil if NPC has no squad. This is not acceptable !
     local squad = get_object_squad(obj)
 
-    return assert(squad, string.format("\n\n%s\n\n%s\n\n%s\n\n%s",
-        this.get_translation("st_err_missing_squad_title"),
-        this.get_translation("st_err_missing_squad_what", obj and obj:name()),
-        this.get_translation("st_err_missing_squad_why"),
-        this.get_translation("st_err_missing_squad_where")
-    ))
+    if not squad then
+        printf("~[WG] WARNING | Utils | Object '%s' has no squad, this will probably crash the game eventually since stalkers/mutants MUST be in squads !", obj and obj:name())
+        return
+    end
+
+    return squad
 end
 
 -- ---------------------------------------------------------------------------------------------------------------------
@@ -949,8 +948,9 @@ function get_real_community(npc, default)
     if not blacklisted_comms[community] then
         return community
     end
-    local squad_community = this.get_squad_of(npc):get_squad_community()
-    if not blacklisted_comms[squad_community] then
+    local squad = this.get_squad_of(npc)
+    local squad_community = squad and squad:get_squad_community()
+    if not squad_community or not blacklisted_comms[squad_community] then
         return squad_community
     else
         return default

--- a/gamedata/scripts/western_goods_utils.script
+++ b/gamedata/scripts/western_goods_utils.script
@@ -707,7 +707,21 @@ function get_squad_of(obj)
         return
     end
 
-    return get_object_squad(obj)
+    -- Maybe don't call 'get_squad_of' on a door or something
+    if not (IsStalker(obj) or IsMonster(obj)) then
+        printf("~[WG] WARNING | Utils | Aborting, trying to get the squad of an object that cannot be in a squad (obj : '%s')", obj and obj:name())
+        return
+    end
+
+    -- Squad can be nil if NPC has no squad. This is not acceptable !
+    local squad = get_object_squad(obj)
+
+    return assert(squad, string.format("\n\n%s\n\n%s\n\n%s\n\n%s",
+        this.get_translation("st_err_missing_squad_title"),
+        this.get_translation("st_err_missing_squad_what", obj and obj:name()),
+        this.get_translation("st_err_missing_squad_why"),
+        this.get_translation("st_err_missing_squad_where")
+    ))
 end
 
 -- ---------------------------------------------------------------------------------------------------------------------
@@ -935,7 +949,7 @@ function get_real_community(npc, default)
     if not blacklisted_comms[community] then
         return community
     end
-    local squad_community = get_object_squad(npc):get_squad_community()
+    local squad_community = this.get_squad_of(npc):get_squad_community()
     if not blacklisted_comms[squad_community] then
         return squad_community
     else


### PR DESCRIPTION
**• Additions :**
> • - Added a warning when trying to get the squad of an object, and the object has no squad;
> • - Added a warning when trying to get the squad of an object that cannot be in a squad;
