### PR TITLE
fix(mcm-rangefinder-nv): Fix Confusing MCM Rangefinder NV Mode

### DIFF
--- a/gamedata/configs/text/eng/st_western_goods_mcm.xml
+++ b/gamedata/configs/text/eng/st_western_goods_mcm.xml
@@ -3,7 +3,7 @@
 <!--                                                                                                                 -->
 <!--    Original Author(s) : NLTP_ASHES                                                                              -->
 <!--    Edited : N/A                                                                                                 -->
-<!--    Date : 11/11/2023                                                                                            -->
+<!--    Date : 13/02/2024                                                                                            -->
 <!--    License : Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0)          -->
 <!--                                                                                                                 -->
 <!--    Translation file for Western Goods' tab in the Mod Configuration Menu.                                       -->
@@ -81,11 +81,11 @@
 
     <!-- Rangefinder Night Vision -->
     <string id="ui_mcm_western_goods_rangefinder_nv">
-        <text>Rangefinder night-vision</text>
+        <text>Toggle Rangefinder reticule color</text>
     </string>
 
     <string id="ui_mcm_western_goods_rangefinder_nv_desc">
-        <text>Key-bind used to enable/disable night-vision for the SigSauer KILO5K Rangefinder.</text>
+        <text>Key-bind used to toggle the color (red/green) of the SigSauer KILO5K Rangefinder's reticule.</text>
     </string>
 
     <!--=============================================================================================================-->

--- a/gamedata/configs/text/rus/st_western_goods_mcm.xml
+++ b/gamedata/configs/text/rus/st_western_goods_mcm.xml
@@ -3,7 +3,7 @@
 <!--                                                                                                                 -->
 <!--    Original Author(s) : NLTP_ASHES                                                                              -->
 <!--    Edited : VodoXleb (Translation)                                                                              -->
-<!--    Date : 11/11/2023                                                                                            -->
+<!--    Date : 13/02/2024                                                                                            -->
 <!--    License : Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0)          -->
 <!--                                                                                                                 -->
 <!--    Translation file for Western Goods' tab in the Mod Configuration Menu.                                       -->
@@ -81,11 +81,11 @@
 
     <!-- Rangefinder Night Vision -->
     <string id="ui_mcm_western_goods_rangefinder_nv">
-        <text>Ночное видение дальномера</text>
+        <text>Переключить цвет сетки дальномера</text>
     </string>
 
     <string id="ui_mcm_western_goods_rangefinder_nv_desc">
-        <text>Кнопка включения/выключения ночного видения для SigSauer KILO5K дальномера.</text>
+        <text>Привязка клавиш используется для переключения цвета (красный/зеленый) прицельной сетки дальномера Sig Sauer KILO5K.</text>
     </string>
 
     <!--=============================================================================================================-->


### PR DESCRIPTION
**• Bug fix :**
> • Fixed the "Rangefinder night-vision mode" option being confusing, and leading to believe the rangefinder had actual NV abilities (Thanks Motorolª).