### PR TITLE
feature(trade-restrictions): Add Trade Restrictions 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 > • Added trade restrictions to the addon's items. Now, traders will only buy the type of items that they would sell.
 
 **• Changes :**
+> • Changed suppliers' trade lists. Before : food, drinks. After : food, magazines ;
+> • Changed barman's trade lists. Before : magazines. After : food, drinks, magazines ;
 > • Simplified code handling EUR/USD trade restrictions by monkey-patching vanilla functions;
 > • Removed dependency on `rax_icon_tint.script`;
 > • Refactored duplicated code in GPS, rangefinder and compass scripts using a new utility function.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 **• Additions :**
 > • Added a new device : the Garmin eTrex 10 electronic compass (Thanks L4U6H1N6-LUN4T1C);
-> • Lighter now displays its fuel level in the item description.
+> • Lighter now displays its fuel level in the item description;
+> • Added trade restrictions to the addon's items. Now, traders will only buy the type of items that they would sell.
 
 **• Changes :**
 > • Simplified code handling EUR/USD trade restrictions by monkey-patching vanilla functions;

--- a/gamedata/scripts/western_goods_core.script
+++ b/gamedata/scripts/western_goods_core.script
@@ -2,7 +2,7 @@
 ---                                                                                                                  ---
 ---    Original Author(s) : NLTP_ASHES                                                                               ---
 ---    Edited : N/A                                                                                                  ---
----    Date : 30/03/2024                                                                                             ---
+---    Date : 01/04/2024                                                                                             ---
 ---    License : Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0)           ---
 ---                                                                                                                  ---
 ---    This script holds the 'core' of the addon.                                                                    ---
@@ -166,7 +166,7 @@ end
 --- Function called from game_tutorials.xml when the player interacts with a campfire.
 --- @return nil
 function use_campfire()
-    printf("[WG] Core | Use Campfire - Called from game_tutorials.xml")
+    dbg_printf("[WG] Core | Use Campfire - Called from game_tutorials.xml")
 end
 
 -- ---------------------------------------------------------------------------------------------------------------------

--- a/gamedata/scripts/western_goods_loot.script
+++ b/gamedata/scripts/western_goods_loot.script
@@ -15,8 +15,8 @@
 
 -- Constants
 local trade_lists = {
-    [trader_autoinject.SUPPLIER]    = { "food", "drink" },
-    [trader_autoinject.BARMAN]      = { "magazine" },
+    [trader_autoinject.SUPPLIER]    = { "food", "magazine" },
+    [trader_autoinject.BARMAN]      = { "food", "drink", "magazine" },
     [trader_autoinject.MECHANIC]    = { "tech" }
 }
 

--- a/gamedata/scripts/western_goods_loot.script
+++ b/gamedata/scripts/western_goods_loot.script
@@ -2,7 +2,7 @@
 ---                                                                                                                  ---
 ---    Original Author(s) : NLTP_ASHES                                                                               ---
 ---    Edited : N/A                                                                                                  ---
----    Date : 19/01/2024                                                                                             ---
+---    Date : 01/04/2024                                                                                             ---
 ---    License : Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0)           ---
 ---                                                                                                                  ---
 ---    This script handles the loot generation (in bodies and traders) for the addon.                                ---
@@ -41,6 +41,35 @@ function spawn_trader_loot(npc)
     dbg_printf("[WG] Core | NPC trading (%s) - type %s\n%s", community, trader_type, utils_data.print_table(trader_table, false, true))
 
     trader_autoinject.spawn_items(npc, trader_table, true)
+end
+
+--- Function used to check if an item is tradable.
+--- Items added through trader_autoinject do not have a proper way to define whether traders should buy them.
+--- @param obj game_object|nil
+--- @param profile table|nil
+--- @return number
+function get_item_trade_status(obj, profile)
+    local partner = ui_inventory.GUI and ui_inventory.GUI:GetPartner()
+
+    -- Only check if an object is tradable when... We have an object
+    if obj and partner then
+        -- Get trader type, list of what the trader sells/buys, and item data
+        local trader_type = trader_autoinject.get_trader_type(partner)
+        local trade_list = trade_lists[trader_type] or {}
+        local item_data = western_goods_core.western_goods_items[obj:section()]
+
+        -- Only WG items have item_data, ignore others
+        if item_data then
+            -- Return appropriate flag (tradable/cant_trade)
+            if western_goods_utils.table_contains(trade_list, item_data.type) then
+                return western_goods_utils.trade_status_flags.tradable
+            else
+                return western_goods_utils.trade_status_flags.cant_trade
+            end
+        end
+    end
+
+    return western_goods_monkey_patches.utils_ui_get_item_trade_status_loot(obj, profile)
 end
 
 -- ---------------------------------------------------------------------------------------------------------------------

--- a/gamedata/scripts/western_goods_monkey_patches.script
+++ b/gamedata/scripts/western_goods_monkey_patches.script
@@ -108,8 +108,14 @@ monkey_patches               = {
             { prio=1, script="ui_item", func="build_desc_header", cond = function() return true end }
         }
     },
-    utils_ui_get_item_trade_status = {
-        name = "utils_ui_get_item_trade_status",
+    utils_ui_get_item_trade_status_eur_usd = {
+        name = "utils_ui_get_item_trade_status_eur_usd",
+        patches = {
+            { prio=1, script="utils_ui", func="get_item_trade_status", cond = function() return true end }
+        }
+    },
+    utils_ui_get_item_trade_status_loot = {
+        name = "utils_ui_get_item_trade_status_loot",
         patches = {
             { prio=1, script="utils_ui", func="get_item_trade_status", cond = function() return true end }
         }
@@ -234,6 +240,10 @@ make_monkey_patch(monkey_patches.ui_item_build_desc_header, function(obj, sec, s
     return western_goods_bind_lighter.build_desc_header(obj, sec, str)
 end)
 
-make_monkey_patch(monkey_patches.utils_ui_get_item_trade_status, function(obj, profile)
+make_monkey_patch(monkey_patches.utils_ui_get_item_trade_status_loot, function(obj, profile)
+    return western_goods_loot.get_item_trade_status(obj, profile)
+end)
+
+make_monkey_patch(monkey_patches.utils_ui_get_item_trade_status_eur_usd, function(obj, profile)
     return western_goods_trade_eur_usd.get_item_trade_status(obj, profile)
 end)

--- a/gamedata/scripts/western_goods_trade_eur_usd.script
+++ b/gamedata/scripts/western_goods_trade_eur_usd.script
@@ -54,7 +54,6 @@ local dbg_printf                = western_goods_utils.dbg_printf
 local level_object_by_id        = western_goods_utils.level_object_by_id
 
 -- Constants
-local trade_status_flags        = { cant_trade = 1, too_damaged = 2, hidden = 3, tradable = 4 }
 local eur_rouble_rate           = 68
 local usd_rouble_rate           = 70
 
@@ -115,15 +114,22 @@ end
 --- @param profile table|nil
 --- @return number
 function get_item_trade_status(obj, profile)
+    -- Get trading partner (if any)
     local partner = ui_inventory.GUI and ui_inventory.GUI:GetPartner()
 
-    if obj and partner
-    and western_goods_trade_eur_usd.is_eur_usd_trader(partner)
-    and not utils_item.in_npc_inv(partner, obj)
-    and not western_goods_trade_eur_usd.is_tradable(obj:section())
-    then return trade_status_flags.cant_trade end
-
-    return western_goods_monkey_patches.utils_ui_get_item_trade_status(obj, profile)
+    if obj and partner and this.is_eur_usd_trader(partner) then
+        -- If player is trading with EUR/USD trader
+        if utils_item.in_npc_inv(partner, obj) or this.is_tradable(obj:section()) then
+            -- Item is tradable if it is in trader inventory or is tradable
+            return western_goods_utils.trade_status_flags.tradable
+        else
+            -- Item is not tradable if it is in player inventory and is not tradable
+            return western_goods_utils.trade_status_flags.cant_trade
+        end
+    else
+        -- Vanilla function decides for other traders
+        return western_goods_monkey_patches.utils_ui_get_item_trade_status_eur_usd(obj, profile)
+    end
 end
 
 --- Monkey-patching ui_inventory.UIInventory.UpdateCharacter to display custom currencies in the character wallet.

--- a/gamedata/scripts/western_goods_utils.script
+++ b/gamedata/scripts/western_goods_utils.script
@@ -2,7 +2,7 @@
 ---                                                                                                                  ---
 ---    Original Author(s) : NLTP_ASHES                                                                               ---
 ---    Edited : N/A                                                                                                  ---
----    Date : 24/03/2024                                                                                             ---
+---    Date : 01/04/2024                                                                                             ---
 ---    License : Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0)           ---
 ---                                                                                                                  ---
 ---    Script used to define various common functions defined in the scripts of the Western Goods addon.             ---
@@ -16,6 +16,8 @@
 local ini_loc                   = ini_file_ex([[localization.ltx]])
 local ini_keys                  = ini_file_ex([[plugins\western_goods\misc\western_goods_key_localization.ltx]])
 local ini_trade                 = ini_file([[items\trade\trade_generic.ltx]])
+
+trade_status_flags              = { cant_trade = 1, too_damaged = 2, hidden = 3, tradable = 4 }
 
 -- ---------------------------------------------------------------------------------------------------------------------
 -- Debug Functions


### PR DESCRIPTION
**• Additions :**
> • Added trade restrictions to the addon's items. Now, traders will only buy the type of items that they would sell.

**• Changes :**
> • Changed suppliers' trade lists. Before : food, drinks. After : food, magazines;
> • Changed barman's trade lists. Before : magazines. After : food, drinks, magazines.