### PR TITLE
feature(pb-cover): Add Readable Playboy Cover

### DIFF
--- a/Western Goods Readables/gamedata/configs/items/items/items_western_goods_readables.ltx
+++ b/Western Goods Readables/gamedata/configs/items/items/items_western_goods_readables.ltx
@@ -37,6 +37,16 @@ wg_readable                                      = true
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+![porn]
+use1_functor                                     = western_goods_ui_readable.menu_view
+use1_action_functor                              = western_goods_ui_readable.use_item
+use1_allow_db                                    = true
+
+; custom properties
+wg_readable                                      = true
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 ![porn2]
 use1_functor                                     = western_goods_ui_readable.menu_view
 use1_action_functor                              = western_goods_ui_readable.use_item

--- a/Western Goods Readables/gamedata/configs/ui/textures_descr/ui_western_goods_readables.xml
+++ b/Western Goods Readables/gamedata/configs/ui/textures_descr/ui_western_goods_readables.xml
@@ -25,6 +25,11 @@
 <!--=================================================================================================================-->
 <w>
 
+    <!-- Russian PLAYBOY (Playboy Hungary Aug 2012) -->
+    <file name="ui\readables\porn\ui_porn.dds">
+        <texture id="ui_porn_page_1"                           x="0"    y="0"    width="4096"    height="2048" />
+    </file>
+
     <!-- Ukrainian MAXIM -->
     <file name="ui\readables\porn2\ui_porn2.dds">
         <texture id="ui_porn2_page_1"                           x="0"    y="0"    width="4096"    height="2048" />


### PR DESCRIPTION
Western Goods Readables module allowed the Anomaly's prn2 mag to be readable (first page) but did not have entries for prn(1) mag. A first page texture is also provided (original issue found, PB Hungary Aug 2012, upscaled/edited).